### PR TITLE
:sparkles: 단말기 심플 리스트 조회 API 추가

### DIFF
--- a/src/main/java/com/uplus/backend/device/controller/DeviceController.java
+++ b/src/main/java/com/uplus/backend/device/controller/DeviceController.java
@@ -6,6 +6,7 @@ import com.uplus.backend.device.dto.DeviceCreateResponseDto;
 import com.uplus.backend.device.dto.DeviceDetailResponseDto;
 import com.uplus.backend.device.dto.DeviceListResponseDto;
 import com.uplus.backend.device.dto.DeviceSelfCompResponseDto;
+import com.uplus.backend.device.dto.DeviceSimpleListResponseDto;
 import com.uplus.backend.device.dto.PriceDetailResponseDto;
 import com.uplus.backend.device.dto.PriceListResponseDto;
 import com.uplus.backend.device.service.DeviceService;
@@ -47,6 +48,18 @@ public class DeviceController {
 	public ResponseEntity<DeviceCreateResponseDto> create(
 		@Valid @RequestBody DeviceCreateRequestDto requestDto) {
 		DeviceCreateResponseDto responseDto = deviceService.create(requestDto);
+
+		return ResponseEntity.ok().body(responseDto);
+	}
+
+	@GetMapping("/simple")
+	@ApiOperation(value = "단말기 심플 리스트 조회", notes = "단말기 심플 리스트를 조회할 수 있다.")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "단말기 심플 리스트 조회 성공"),
+		@ApiResponse(code = 500, message = "서버 오류")
+	})
+	public ResponseEntity<DeviceSimpleListResponseDto> getSimpleDevices() {
+		DeviceSimpleListResponseDto responseDto = deviceService.getSimpleDevices();
 
 		return ResponseEntity.ok().body(responseDto);
 	}

--- a/src/main/java/com/uplus/backend/device/dto/DeviceSimpleListResponseDto.java
+++ b/src/main/java/com/uplus/backend/device/dto/DeviceSimpleListResponseDto.java
@@ -1,0 +1,22 @@
+package com.uplus.backend.device.dto;
+
+import com.uplus.backend.device.entity.Device;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeviceSimpleListResponseDto {
+
+	private List<DeviceSimpleResponseDto> devices;
+
+	public static DeviceSimpleListResponseDto fromEntity(List<Device> devices) {
+		return DeviceSimpleListResponseDto.builder()
+			.devices(devices.stream()
+				.map(DeviceSimpleResponseDto::fromEntity)
+				.collect(Collectors.toList()))
+			.build();
+	}
+}

--- a/src/main/java/com/uplus/backend/device/dto/DeviceSimpleResponseDto.java
+++ b/src/main/java/com/uplus/backend/device/dto/DeviceSimpleResponseDto.java
@@ -1,0 +1,32 @@
+package com.uplus.backend.device.dto;
+
+import com.uplus.backend.device.entity.Device;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeviceSimpleResponseDto {
+
+	@ApiModelProperty(name = "단말기 식별자", example = "1")
+	private Long id;
+
+	@ApiModelProperty(name = "단말기명", example = "갤럭시 S22")
+	private String name;
+
+	@ApiModelProperty(name = "제조사", example = "삼성")
+	private String company;
+
+	@ApiModelProperty(name = "네트워크 타입", example = "5")
+	private int networkType;
+
+	public static DeviceSimpleResponseDto fromEntity(Device device) {
+		return DeviceSimpleResponseDto.builder()
+			.id(device.getId())
+			.name(device.getName())
+			.company(device.getCompany())
+			.networkType(device.getNetworkType())
+			.build();
+	}
+}

--- a/src/main/java/com/uplus/backend/device/service/DeviceService.java
+++ b/src/main/java/com/uplus/backend/device/service/DeviceService.java
@@ -5,6 +5,7 @@ import com.uplus.backend.device.dto.DeviceCreateResponseDto;
 import com.uplus.backend.device.dto.DeviceDetailResponseDto;
 import com.uplus.backend.device.dto.DeviceListResponseDto;
 import com.uplus.backend.device.dto.DeviceSelfCompResponseDto;
+import com.uplus.backend.device.dto.DeviceSimpleListResponseDto;
 import com.uplus.backend.device.dto.PriceListResponseDto;
 import com.uplus.backend.device.dto.PriceDetailResponseDto;
 import com.uplus.backend.device.entity.Device;
@@ -37,6 +38,13 @@ public class DeviceService {
 		device = deviceRepository.save(device);
 
 		return DeviceCreateResponseDto.fromEntity(device);
+	}
+
+	@Transactional(readOnly = true)
+	public DeviceSimpleListResponseDto getSimpleDevices() {
+		List<Device> devices = deviceRepository.findAll();
+
+		return DeviceSimpleListResponseDto.fromEntity(devices);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/test/java/com/uplus/backend/integration/device/DeviceIntegrationTest.java
+++ b/src/test/java/com/uplus/backend/integration/device/DeviceIntegrationTest.java
@@ -68,7 +68,7 @@ public class DeviceIntegrationTest {
 	private Image image1;
 
 	@BeforeAll
-	private void setup() {
+	public void setup() {
 		// given
 		plan1 = Plan.builder()
 			.name("요금제1")
@@ -170,6 +170,14 @@ public class DeviceIntegrationTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(requestDto)))
 			.andExpect(status().isNotFound())
+			.andDo(print());
+	}
+
+	@Test
+	void 단말기_심플_리스트_조회_테스트() throws Exception {
+		// when & then
+		mockMvc.perform(get("/api/devices/simple"))
+			.andExpect(status().isOk())
 			.andDo(print());
 	}
 


### PR DESCRIPTION
## 📌 개발 내용
- resolve #54 
- 단말기 심플 리스트 조회 API 추가
  <br>

## 💻  변경 내용
- `GET /api/devices/simple`
- 통합 테스트 코드 작성
  <br>
