### PR TITLE
:recycle: 장바구니 구현방식 변경

### DIFF
--- a/src/main/java/com/uplus/backend/cart/controller/CartController.java
+++ b/src/main/java/com/uplus/backend/cart/controller/CartController.java
@@ -34,12 +34,13 @@ public class CartController {
     @ApiOperation(value = "장바구니 항목 추가", notes = "장바구니 항목을 추가한다.")
     @ApiResponses({
         @ApiResponse(code = 200, message = "장바구니 항목 추가 성공"),
+        @ApiResponse(code = 400, message = "잘못된 장바구니 생성 정보 전송"),
         @ApiResponse(code = 404, message = "존재하지 않는 데이터"),
     })
     public ResponseEntity<CartListResponseDto> createCartItem(
         @Valid @RequestBody CartRequestDto request, @PathVariable("cartId") Long cartId) {
 
-        CartListResponseDto cartListResponseDto;   cartListResponseDto = cartService.create(request, cartId);
+        CartListResponseDto cartListResponseDto = cartService.create(request, cartId);
 
         return ResponseEntity.ok().body(cartListResponseDto);
     }

--- a/src/main/java/com/uplus/backend/cart/controller/CartController.java
+++ b/src/main/java/com/uplus/backend/cart/controller/CartController.java
@@ -30,36 +30,16 @@ public class CartController {
 
     private final CartService cartService;
 
-    @PostMapping("")
+    @PostMapping("/{cartId}")
     @ApiOperation(value = "장바구니 항목 추가", notes = "장바구니 항목을 추가한다.")
     @ApiResponses({
         @ApiResponse(code = 200, message = "장바구니 항목 추가 성공"),
         @ApiResponse(code = 404, message = "존재하지 않는 데이터"),
     })
     public ResponseEntity<CartListResponseDto> createCartItem(
-        @Valid @RequestBody CartRequestDto request, @CookieValue(name = "cartId", required = false) Long cartId, HttpServletResponse response) {
+        @Valid @RequestBody CartRequestDto request, @PathVariable("cartId") Long cartId) {
 
-        CartListResponseDto cartListResponseDto;
-
-        if (cartId == null) {
-            cartId = -1L;
-            cartListResponseDto = cartService.create(request, cartId);
-            Cookie cartIdCookie = new Cookie("cartId", String.valueOf(cartListResponseDto.getCarts().get(0).getCartId()));
-            Cookie cartCountCookie = new Cookie("cartCount", String.valueOf(cartListResponseDto.getCarts().size()));
-            cartIdCookie.setMaxAge(60 * 60 * 24 * 365);
-            cartIdCookie.setDomain("localhost");
-            cartIdCookie.setPath("/");
-            cartIdCookie.setSecure(true);
-            response.addCookie(cartIdCookie);
-
-            cartCountCookie.setMaxAge(60 * 60 * 24 * 365);
-            cartCountCookie.setDomain("localhost");
-            cartCountCookie.setPath("/");
-            cartCountCookie.setSecure(true);
-            response.addCookie(cartCountCookie);
-        } else {
-            cartListResponseDto = cartService.create(request, cartId);
-        }
+        CartListResponseDto cartListResponseDto;   cartListResponseDto = cartService.create(request, cartId);
 
         return ResponseEntity.ok().body(cartListResponseDto);
     }


### PR DESCRIPTION
## 📌 개발 내용
- resolve #73 
- 장바구니 구현방식 변경
  <br>

## 💻  변경 내용
- 장바구니 항목 생성 api를 변경했습니다.
  <br>

## ✅ PR Point
![image](https://user-images.githubusercontent.com/55776650/188316571-f0800b18-5018-4cf4-b0fa-db5363d70936.png)
- 기존 CookieValue로 받아오던 장바구니 아이디를 PathVariable로 변경했습니다.
- 백엔드에서 세팅해주던 쿠키값을 프론드엔드에서 세팅하는 방식으로 변경했습니다.
